### PR TITLE
Switch over to using configparser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 config.py
 db.pickle
+*.cfg

--- a/config.py.sample
+++ b/config.py.sample
@@ -1,7 +1,0 @@
-API_KEY = "api key goes here"
-NUM_PROCS = 6
-NETBOX_URL = "https://netbox.example.ac.uk"
-PREFIX_TAG = "scanrig"
-LAST_SEEN_DATABASE = "db.pickle"
-# The hostname the scanner is running from
-PROD_HOSTNAME = "scanner.example.ac.uk"

--- a/netbox_ip_status.cfg.default
+++ b/netbox_ip_status.cfg.default
@@ -1,0 +1,6 @@
+[NETBOX]
+URL = https://localhost
+PREFIX_TAG = scanme
+
+[SCANNER]
+LAST_SEEN_DATABASE = db.pickle

--- a/netbox_ip_status.cfg.example
+++ b/netbox_ip_status.cfg.example
@@ -1,0 +1,9 @@
+[NETBOX]
+API_KEY = api key goes here
+URL = https://netbox.example.org
+PREFIX_TAG = scanme
+
+[SCANNER]
+LAST_SEEN_DATABASE = db.pickle
+# The hostname the scanner is running from
+PROD_HOSTNAME = scanner.example.org

--- a/netbox_ip_status.py
+++ b/netbox_ip_status.py
@@ -2,7 +2,7 @@
 
 """ Script to tag IPs in NetBox with when they were last pingable """
 
-import config
+from configparser import ConfigParser
 import datetime
 import os
 import pickle
@@ -120,12 +120,17 @@ def update_address(ipy_address, prefix_mask):
 
 
 def main():
-    if socket.getfqdn() != config.PROD_HOSTNAME:
+    global last_seen
+
+    config = ConfigParser()
+    config.read(['netbox_ip_status.cfg.default', 'netbox_ip_status.cfg'])
+
+    if socket.getfqdn() != config['SCANNER']['PROD_HOSTNAME']:
         sys.exit(0)
 
-    if os.path.exists(config.LAST_SEEN_DATABASE):
+    if os.path.exists(config['SCANNER']['LAST_SEEN_DATABASE']):
         try:
-            last_seen = pickle.load(open(config.LAST_SEEN_DATABASE, "rb"))
+            last_seen = pickle.load(open(config['SCANNER']['LAST_SEEN_DATABASE'], "rb"))
         except Exception:
             pass
 
@@ -134,7 +139,7 @@ def main():
         prefix_mask = prefix.prefix.split("/")[1]
         update_addresses(prefix_ip_object, prefix_mask)
 
-    pickle.dump(last_seen, open(config.LAST_SEEN_DATABASE, "wb"))
+    pickle.dump(last_seen, open(config['SCANNER']['LAST_SEEN_DATABASE'], "wb"))
 
 
 if __name__ == "__main__":

--- a/netbox_ip_status.py
+++ b/netbox_ip_status.py
@@ -30,9 +30,11 @@ today = today_datetime.strftime('%Y-%m-%d')
 
 last_seen = {}
 
+
 def update_addresses(addresses, prefix_mask):
     for address in addresses:
         update_address(address, prefix_mask)
+
 
 def reverse_lookup(ip):
     try:
@@ -40,6 +42,7 @@ def reverse_lookup(ip):
         return hostname
     except socket.herror:
         return None
+
 
 def update_address(ipy_address, prefix_mask):
     ip = ipy_address.strNormal()
@@ -115,6 +118,7 @@ def update_address(ipy_address, prefix_mask):
         # Lets just go to the next one
         print(e)
 
+
 def main():
     if socket.getfqdn() != config.PROD_HOSTNAME:
         sys.exit(0)
@@ -131,6 +135,7 @@ def main():
         update_addresses(prefix_ip_object, prefix_mask)
 
     pickle.dump(last_seen, open(config.LAST_SEEN_DATABASE, "wb"))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is safer and more robust than treating it as Python code.

- Provide a defaults file and change default/example values to be more generic,
  e.g use "example.org" which is reserved for documentation/examples.
- Remove unused setting from config file

This also moves some of the globals (session and prefixes) into the main function and passes them as required.