### PR TITLE
Rewrite to use fping for bulk scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,5 @@
 Show when an IP address was last seen, and its actual reverse DNS record in Netbox
 
 Copy config.py.sample to config.py and edit as appropriate.
-This script needs to run with root privileges for its ping functionality.
 
 Run on a cronjob once a day.

--- a/netbox_ip_status.cfg.default
+++ b/netbox_ip_status.cfg.default
@@ -4,3 +4,4 @@ PREFIX_TAG = scanme
 
 [SCANNER]
 LAST_SEEN_DATABASE = db.pickle
+LOG_LEVEL = INFO

--- a/netbox_ip_status.py
+++ b/netbox_ip_status.py
@@ -82,6 +82,10 @@ def update_tag(address, new_tag):
             address.tags.remove(tag)
             address.tags.append(new_tag)
             updated = True
+            break
+    else:
+        address.tags.append(new_tag)
+        updated = True
     logger.debug("Tags after: %s", address.tags)
     return address, updated
 

--- a/netbox_ip_status.py
+++ b/netbox_ip_status.py
@@ -108,30 +108,29 @@ def process_address(netbox, ipy_address, prefix_mask, is_alive):
     ip = ipy_address.strNormal()
     rev_updated = False
     tag_updated = False
-    try:
-        rev = reverse_lookup(ip)
-        logger.debug("reverse DNS is %s", rev)
-        address = netbox.ipam.ip_addresses.get(address=ipy_address.strNormal(1))
-        if address is not None:
-            new_tag = generate_tag(address, is_alive)
-            address, tag_updated = update_tag(address, new_tag)
 
-            # Only update reverse DNS if it changes
-            if rev is not None:
-                if address.dns_name != rev:
-                    address.dns_name = rev
-                    rev_updated = True
+    rev = reverse_lookup(ip)
+    logger.debug("reverse DNS is %s", rev)
+
+    address = netbox.ipam.ip_addresses.get(address=ipy_address.strNormal(1))
+
+    if address is not None:
+        new_tag = generate_tag(address, is_alive)
+        address, tag_updated = update_tag(address, new_tag)
+
+        # Only update reverse DNS if it changes
+        if rev is not None:
+            if address.dns_name != rev:
+                address.dns_name = rev
+                rev_updated = True
 
         if rev_updated or tag_updated:
             address.save()
 
-        elif is_alive:
-            # The address does not currently exist in Netbox, so lets add a reservation so somebody does not re-use it.
-            add_address(netbox, ipy_address, prefix_mask, rev)
+    elif is_alive:
+        # The address does not currently exist in Netbox, so lets add a reservation so somebody does not re-use it.
+        add_address(netbox, ipy_address, prefix_mask, rev)
 
-    except ValueError as e:
-        # Lets just go to the next one
-        print(e)
 
 
 def main():


### PR DESCRIPTION
Based on #7.

Making use of `fping`'s highly optimised multithreaded ping capability dramatically improves performance, in testing the time to scan four /27 was reduced from 3m50s to just 34s.

Additionally `fping` has `cap_net_raw=ep` so the whole script can be run as a non-root user.